### PR TITLE
refactor: Rename jobNature to Employees and seed data

### DIFF
--- a/EEMS.BusinessLogic/Services/EmployeeService.cs
+++ b/EEMS.BusinessLogic/Services/EmployeeService.cs
@@ -16,17 +16,17 @@ namespace EEMS.BusinessLogic.Services
 
         public async Task<IEnumerable<Employee>> GetAsync()
         {
-            return await _context.jobNature.ToListAsync();
+            return await _context.Employees.ToListAsync();
         }
 
         public async Task<Employee> GetAsync(int id)
         {
-            return await _context.jobNature.FindAsync(id);
+            return await _context.Employees.FindAsync(id);
         }
 
         public async Task<int> AddAsync(Employee employee)
         {
-            var added = _context.jobNature.Add(employee);
+            var added = _context.Employees.Add(employee);
             await _context.SaveChangesAsync();
 
             return added.Entity.Id;
@@ -34,7 +34,7 @@ namespace EEMS.BusinessLogic.Services
 
         public async Task UpdateAsync(Employee employee)
         {
-            _context.jobNature.Update(employee);
+            _context.Employees.Update(employee);
             await _context.SaveChangesAsync();
         }
 
@@ -43,7 +43,7 @@ namespace EEMS.BusinessLogic.Services
             var emp = await GetAsync(id);
             if (emp != null)
             {
-                _context.jobNature.Remove(emp);
+                _context.Employees.Remove(emp);
                 await _context.SaveChangesAsync();
             }
         }

--- a/EEMS.DataAccess/EEMSDbContext.cs
+++ b/EEMS.DataAccess/EEMSDbContext.cs
@@ -1,4 +1,5 @@
-﻿using EEMS.DataAccess.Models;
+﻿using EEMS.DataAccess.Enums;
+using EEMS.DataAccess.Models;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Conventions;
 
@@ -6,7 +7,7 @@ namespace EEMS.DataAccess
 {
     public class EEMSDbContext : DbContext
     {
-        public DbSet<Employee> jobNature { get; set; }
+        public DbSet<Employee> Employees { get; set; }
         public DbSet<Department> Departments { get; set; }
         public DbSet<Project> Projects { get; set; }
         public DbSet<Absence> Absences { get; set; }
@@ -76,6 +77,142 @@ namespace EEMS.DataAccess
                 .HasOne(e => e.JobNature)
                 .WithMany(j => j.Employees)
                 .HasForeignKey(e => e.JobNatureId);
+
+
+            // Data seeding
+
+            modelBuilder.Entity<Department>().HasData(
+                new Department { Id=1, Name="Human Resources"},
+                new Department { Id=2, Name="Budget and Accounting"},
+                new Department { Id=3, Name="General Administration"}
+                );
+
+            modelBuilder.Entity<Project>().HasData(
+                new Project { Id=1, Name="Gas maintanance" ,Place="Tamanraset"},
+                new Project { Id=2, Name="Gas Finding" ,Place="Ain Salah"},
+                new Project { Id=3, Name= "Gas Tube Manufacture", Place="Djanat"}
+                );
+
+            modelBuilder.Entity<JobNature>().HasData(
+                new JobNature { Id=1, Name="Full-time Work"},
+                new JobNature { Id=2, Name="Part-time Work"},
+                new JobNature { Id=3, Name="Temporary Work"}
+                );
+
+            modelBuilder.Entity<Employee>().HasData(
+                new Employee
+                {
+                    Id = 1,
+                    FirstName = "John",
+                    LastName = "Doe",
+                    Phone = "123-456-7890",
+                    JobTitle = "Software Engineer",
+                    Email = "john.doe@example.com",
+                    Training = "C#, .NET, SQL",
+                    DateOfBirth = new DateTime(1990, 5, 15),
+                    BirthLocation = "New York, USA",
+                    Address = "123 Main St, New York, USA",
+                    FamilySituation = "Single",
+                    RecruitmentDate = new DateTime(2020, 1, 10),
+                    Gender = Gender.Male,
+                    Residence = "New York, USA",
+                    IsActive = true,
+                    IsDeleted = false,
+                    DepartmentId = 1,
+                    ProjectId = 1,    
+                    JobNatureId = 1   
+                },
+                new Employee
+                {
+                    Id = 2,
+                    FirstName = "Jane",
+                    LastName = "Smith",
+                    Phone = "987-654-3210",
+                    JobTitle = "Project Manager",
+                    Email = "jane.smith@example.com",
+                    Training = "PMP, Agile, Scrum",
+                    DateOfBirth = new DateTime(1985, 8, 20),
+                    BirthLocation = "Los Angeles, USA",
+                    Address = "456 Elm St, Los Angeles, USA",
+                    FamilySituation = "Married",
+                    RecruitmentDate = new DateTime(2018, 3, 22),
+                    Gender = Gender.Female,
+                    Residence = "Los Angeles, USA",
+                    IsActive = true,
+                    IsDeleted = false,
+                    DepartmentId = 2, 
+                    ProjectId = 2,    
+                    JobNatureId = 2   
+                },
+                new Employee
+                {
+                    Id = 3,
+                    FirstName = "Alice",
+                    LastName = "Johnson",
+                    Phone = "555-123-4567",
+                    JobTitle = "QA Engineer",
+                    Email = "alice.johnson@example.com",
+                    Training = "Selenium, Manual Testing",
+                    DateOfBirth = new DateTime(1992, 12, 5),
+                    BirthLocation = "Chicago, USA",
+                    Address = "789 Oak St, Chicago, USA",
+                    FamilySituation = "Single",
+                    RecruitmentDate = new DateTime(2021, 7, 15),
+                    Gender = Gender.Female,
+                    Residence = "Chicago, USA",
+                    IsActive = true,
+                    IsDeleted = false,
+                    DepartmentId = 1, 
+                    ProjectId = 1,    
+                    JobNatureId = 3   
+                },
+                new Employee
+                {
+                    Id = 4,
+                    FirstName = "Bob",
+                    LastName = "Brown",
+                    Phone = "444-555-6666",
+                    JobTitle = "DevOps Engineer",
+                    Email = "bob.brown@example.com",
+                    Training = "Docker, Kubernetes, Azure",
+                    DateOfBirth = new DateTime(1988, 3, 25),
+                    BirthLocation = "Houston, USA",
+                    Address = "321 Pine St, Houston, USA",
+                    FamilySituation = "Married",
+                    RecruitmentDate = new DateTime(2019, 9, 30),
+                    Gender = Gender.Male,
+                    Residence = "Houston, USA",
+                    IsActive = true,
+                    IsDeleted = false,
+                    DepartmentId = 3, 
+                    ProjectId = 3,    
+                    JobNatureId = 1   
+                },
+                new Employee
+                {
+                    Id = 5,
+                    FirstName = "Charlie",
+                    LastName = "Davis",
+                    Phone = "777-888-9999",
+                    JobTitle = "UI/UX Designer",
+                    Email = "charlie.davis@example.com",
+                    Training = "Figma, Adobe XD, Sketch",
+                    DateOfBirth = new DateTime(1995, 7, 10),
+                    BirthLocation = "Miami, USA",
+                    Address = "654 Beach St, Miami, USA",
+                    FamilySituation = "Single",
+                    RecruitmentDate = new DateTime(2022, 2, 5),
+                    Gender = Gender.Male,
+                    Residence = "Miami, USA",
+                    IsActive = true,
+                    IsDeleted = false,
+                    DepartmentId = 2,
+                    ProjectId = 1,    
+                    JobNatureId = 3
+                });
+
+
+
         }
     }
 }

--- a/EEMS.DataAccess/Migrations/20250221022527_SeedEmployeeData.Designer.cs
+++ b/EEMS.DataAccess/Migrations/20250221022527_SeedEmployeeData.Designer.cs
@@ -4,6 +4,7 @@ using EEMS.DataAccess;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EEMS.DataAccess.Migrations
 {
     [DbContext(typeof(EEMSDbContext))]
-    partial class EEMSDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250221022527_SeedEmployeeData")]
+    partial class SeedEmployeeData
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -212,7 +215,7 @@ namespace EEMS.DataAccess.Migrations
 
                     b.HasIndex("ProjectId");
 
-                    b.ToTable("Employees");
+                    b.ToTable("jobNature");
 
                     b.HasData(
                         new

--- a/EEMS.DataAccess/Migrations/20250221022527_SeedEmployeeData.cs
+++ b/EEMS.DataAccess/Migrations/20250221022527_SeedEmployeeData.cs
@@ -1,0 +1,303 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+#pragma warning disable CA1814 // Prefer jagged arrays over multidimensional
+
+namespace EEMS.DataAccess.Migrations
+{
+    /// <inheritdoc />
+    public partial class SeedEmployeeData : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Absences_Employees_EmployeeId",
+                table: "Absences");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_EmployeeDrivingLicenses_Employees_EmployeeId",
+                table: "EmployeeDrivingLicenses");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Employees_Departments_DepartmentId",
+                table: "Employees");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Employees_JobNatures_JobNatureId",
+                table: "Employees");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Employees_Projects_ProjectId",
+                table: "Employees");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_Employees",
+                table: "Employees");
+
+            migrationBuilder.RenameTable(
+                name: "Employees",
+                newName: "jobNature");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_Employees_ProjectId",
+                table: "jobNature",
+                newName: "IX_jobNature_ProjectId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_Employees_JobNatureId",
+                table: "jobNature",
+                newName: "IX_jobNature_JobNatureId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_Employees_DepartmentId",
+                table: "jobNature",
+                newName: "IX_jobNature_DepartmentId");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_jobNature",
+                table: "jobNature",
+                column: "Id");
+
+            migrationBuilder.InsertData(
+                table: "Departments",
+                columns: new[] { "Id", "Name" },
+                values: new object[,]
+                {
+                    { 1, "Human Resources" },
+                    { 2, "Budget and Accounting" },
+                    { 3, "General Administration" }
+                });
+
+            migrationBuilder.InsertData(
+                table: "JobNatures",
+                columns: new[] { "Id", "Name" },
+                values: new object[,]
+                {
+                    { 1, "Full-time Work" },
+                    { 2, "Part-time Work" },
+                    { 3, "Temporary Work" }
+                });
+
+            migrationBuilder.InsertData(
+                table: "Projects",
+                columns: new[] { "Id", "Name", "Place" },
+                values: new object[,]
+                {
+                    { 1, "Gas maintanance", "Tamanraset" },
+                    { 2, "Gas Finding", "Ain Salah" },
+                    { 3, "Gas Tube Manufacture", "Djanat" }
+                });
+
+            migrationBuilder.InsertData(
+                table: "jobNature",
+                columns: new[] { "Id", "Address", "BirthLocation", "DateOfBirth", "DepartmentId", "Email", "EssentialTraining", "Experience", "FamilySituation", "FirstName", "Gender", "IsActive", "IsDeleted", "JobNatureId", "JobTitle", "LanguagesSpoken", "LastName", "Phone", "ProjectId", "RecruitmentDate", "Residence", "Training" },
+                values: new object[,]
+                {
+                    { 1, "123 Main St, New York, USA", "New York, USA", new DateTime(1990, 5, 15, 0, 0, 0, 0, DateTimeKind.Unspecified), 1, "john.doe@example.com", null, null, "Single", "John", 0, true, false, 1, "Software Engineer", null, "Doe", "123-456-7890", 1, new DateTime(2020, 1, 10, 0, 0, 0, 0, DateTimeKind.Unspecified), "New York, USA", "C#, .NET, SQL" },
+                    { 2, "456 Elm St, Los Angeles, USA", "Los Angeles, USA", new DateTime(1985, 8, 20, 0, 0, 0, 0, DateTimeKind.Unspecified), 2, "jane.smith@example.com", null, null, "Married", "Jane", 1, true, false, 2, "Project Manager", null, "Smith", "987-654-3210", 2, new DateTime(2018, 3, 22, 0, 0, 0, 0, DateTimeKind.Unspecified), "Los Angeles, USA", "PMP, Agile, Scrum" },
+                    { 3, "789 Oak St, Chicago, USA", "Chicago, USA", new DateTime(1992, 12, 5, 0, 0, 0, 0, DateTimeKind.Unspecified), 1, "alice.johnson@example.com", null, null, "Single", "Alice", 1, true, false, 3, "QA Engineer", null, "Johnson", "555-123-4567", 1, new DateTime(2021, 7, 15, 0, 0, 0, 0, DateTimeKind.Unspecified), "Chicago, USA", "Selenium, Manual Testing" },
+                    { 4, "321 Pine St, Houston, USA", "Houston, USA", new DateTime(1988, 3, 25, 0, 0, 0, 0, DateTimeKind.Unspecified), 3, "bob.brown@example.com", null, null, "Married", "Bob", 0, true, false, 1, "DevOps Engineer", null, "Brown", "444-555-6666", 3, new DateTime(2019, 9, 30, 0, 0, 0, 0, DateTimeKind.Unspecified), "Houston, USA", "Docker, Kubernetes, Azure" },
+                    { 5, "654 Beach St, Miami, USA", "Miami, USA", new DateTime(1995, 7, 10, 0, 0, 0, 0, DateTimeKind.Unspecified), 2, "charlie.davis@example.com", null, null, "Single", "Charlie", 0, true, false, 3, "UI/UX Designer", null, "Davis", "777-888-9999", 1, new DateTime(2022, 2, 5, 0, 0, 0, 0, DateTimeKind.Unspecified), "Miami, USA", "Figma, Adobe XD, Sketch" }
+                });
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Absences_jobNature_EmployeeId",
+                table: "Absences",
+                column: "EmployeeId",
+                principalTable: "jobNature",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_EmployeeDrivingLicenses_jobNature_EmployeeId",
+                table: "EmployeeDrivingLicenses",
+                column: "EmployeeId",
+                principalTable: "jobNature",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_jobNature_Departments_DepartmentId",
+                table: "jobNature",
+                column: "DepartmentId",
+                principalTable: "Departments",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_jobNature_JobNatures_JobNatureId",
+                table: "jobNature",
+                column: "JobNatureId",
+                principalTable: "JobNatures",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_jobNature_Projects_ProjectId",
+                table: "jobNature",
+                column: "ProjectId",
+                principalTable: "Projects",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Absences_jobNature_EmployeeId",
+                table: "Absences");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_EmployeeDrivingLicenses_jobNature_EmployeeId",
+                table: "EmployeeDrivingLicenses");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_jobNature_Departments_DepartmentId",
+                table: "jobNature");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_jobNature_JobNatures_JobNatureId",
+                table: "jobNature");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_jobNature_Projects_ProjectId",
+                table: "jobNature");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_jobNature",
+                table: "jobNature");
+
+            migrationBuilder.DeleteData(
+                table: "jobNature",
+                keyColumn: "Id",
+                keyValue: 1);
+
+            migrationBuilder.DeleteData(
+                table: "jobNature",
+                keyColumn: "Id",
+                keyValue: 2);
+
+            migrationBuilder.DeleteData(
+                table: "jobNature",
+                keyColumn: "Id",
+                keyValue: 3);
+
+            migrationBuilder.DeleteData(
+                table: "jobNature",
+                keyColumn: "Id",
+                keyValue: 4);
+
+            migrationBuilder.DeleteData(
+                table: "jobNature",
+                keyColumn: "Id",
+                keyValue: 5);
+
+            migrationBuilder.DeleteData(
+                table: "Departments",
+                keyColumn: "Id",
+                keyValue: 1);
+
+            migrationBuilder.DeleteData(
+                table: "Departments",
+                keyColumn: "Id",
+                keyValue: 2);
+
+            migrationBuilder.DeleteData(
+                table: "Departments",
+                keyColumn: "Id",
+                keyValue: 3);
+
+            migrationBuilder.DeleteData(
+                table: "JobNatures",
+                keyColumn: "Id",
+                keyValue: 1);
+
+            migrationBuilder.DeleteData(
+                table: "JobNatures",
+                keyColumn: "Id",
+                keyValue: 2);
+
+            migrationBuilder.DeleteData(
+                table: "JobNatures",
+                keyColumn: "Id",
+                keyValue: 3);
+
+            migrationBuilder.DeleteData(
+                table: "Projects",
+                keyColumn: "Id",
+                keyValue: 1);
+
+            migrationBuilder.DeleteData(
+                table: "Projects",
+                keyColumn: "Id",
+                keyValue: 2);
+
+            migrationBuilder.DeleteData(
+                table: "Projects",
+                keyColumn: "Id",
+                keyValue: 3);
+
+            migrationBuilder.RenameTable(
+                name: "jobNature",
+                newName: "Employees");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_jobNature_ProjectId",
+                table: "Employees",
+                newName: "IX_Employees_ProjectId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_jobNature_JobNatureId",
+                table: "Employees",
+                newName: "IX_Employees_JobNatureId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_jobNature_DepartmentId",
+                table: "Employees",
+                newName: "IX_Employees_DepartmentId");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_Employees",
+                table: "Employees",
+                column: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Absences_Employees_EmployeeId",
+                table: "Absences",
+                column: "EmployeeId",
+                principalTable: "Employees",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_EmployeeDrivingLicenses_Employees_EmployeeId",
+                table: "EmployeeDrivingLicenses",
+                column: "EmployeeId",
+                principalTable: "Employees",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Employees_Departments_DepartmentId",
+                table: "Employees",
+                column: "DepartmentId",
+                principalTable: "Departments",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Employees_JobNatures_JobNatureId",
+                table: "Employees",
+                column: "JobNatureId",
+                principalTable: "JobNatures",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Employees_Projects_ProjectId",
+                table: "Employees",
+                column: "ProjectId",
+                principalTable: "Projects",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/EEMS.DataAccess/Migrations/20250221024105_RenameJobNatureToEmployees.Designer.cs
+++ b/EEMS.DataAccess/Migrations/20250221024105_RenameJobNatureToEmployees.Designer.cs
@@ -4,6 +4,7 @@ using EEMS.DataAccess;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -11,9 +12,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace EEMS.DataAccess.Migrations
 {
     [DbContext(typeof(EEMSDbContext))]
-    partial class EEMSDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250221024105_RenameJobNatureToEmployees")]
+    partial class RenameJobNatureToEmployees
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/EEMS.DataAccess/Migrations/20250221024105_RenameJobNatureToEmployees.cs
+++ b/EEMS.DataAccess/Migrations/20250221024105_RenameJobNatureToEmployees.cs
@@ -1,0 +1,188 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace EEMS.DataAccess.Migrations
+{
+    /// <inheritdoc />
+    public partial class RenameJobNatureToEmployees : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Absences_jobNature_EmployeeId",
+                table: "Absences");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_EmployeeDrivingLicenses_jobNature_EmployeeId",
+                table: "EmployeeDrivingLicenses");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_jobNature_Departments_DepartmentId",
+                table: "jobNature");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_jobNature_JobNatures_JobNatureId",
+                table: "jobNature");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_jobNature_Projects_ProjectId",
+                table: "jobNature");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_jobNature",
+                table: "jobNature");
+
+            migrationBuilder.RenameTable(
+                name: "jobNature",
+                newName: "Employees");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_jobNature_ProjectId",
+                table: "Employees",
+                newName: "IX_Employees_ProjectId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_jobNature_JobNatureId",
+                table: "Employees",
+                newName: "IX_Employees_JobNatureId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_jobNature_DepartmentId",
+                table: "Employees",
+                newName: "IX_Employees_DepartmentId");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_Employees",
+                table: "Employees",
+                column: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Absences_Employees_EmployeeId",
+                table: "Absences",
+                column: "EmployeeId",
+                principalTable: "Employees",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_EmployeeDrivingLicenses_Employees_EmployeeId",
+                table: "EmployeeDrivingLicenses",
+                column: "EmployeeId",
+                principalTable: "Employees",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Employees_Departments_DepartmentId",
+                table: "Employees",
+                column: "DepartmentId",
+                principalTable: "Departments",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Employees_JobNatures_JobNatureId",
+                table: "Employees",
+                column: "JobNatureId",
+                principalTable: "JobNatures",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Employees_Projects_ProjectId",
+                table: "Employees",
+                column: "ProjectId",
+                principalTable: "Projects",
+                principalColumn: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Absences_Employees_EmployeeId",
+                table: "Absences");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_EmployeeDrivingLicenses_Employees_EmployeeId",
+                table: "EmployeeDrivingLicenses");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Employees_Departments_DepartmentId",
+                table: "Employees");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Employees_JobNatures_JobNatureId",
+                table: "Employees");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_Employees_Projects_ProjectId",
+                table: "Employees");
+
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_Employees",
+                table: "Employees");
+
+            migrationBuilder.RenameTable(
+                name: "Employees",
+                newName: "jobNature");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_Employees_ProjectId",
+                table: "jobNature",
+                newName: "IX_jobNature_ProjectId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_Employees_JobNatureId",
+                table: "jobNature",
+                newName: "IX_jobNature_JobNatureId");
+
+            migrationBuilder.RenameIndex(
+                name: "IX_Employees_DepartmentId",
+                table: "jobNature",
+                newName: "IX_jobNature_DepartmentId");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_jobNature",
+                table: "jobNature",
+                column: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Absences_jobNature_EmployeeId",
+                table: "Absences",
+                column: "EmployeeId",
+                principalTable: "jobNature",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_EmployeeDrivingLicenses_jobNature_EmployeeId",
+                table: "EmployeeDrivingLicenses",
+                column: "EmployeeId",
+                principalTable: "jobNature",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_jobNature_Departments_DepartmentId",
+                table: "jobNature",
+                column: "DepartmentId",
+                principalTable: "Departments",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_jobNature_JobNatures_JobNatureId",
+                table: "jobNature",
+                column: "JobNatureId",
+                principalTable: "JobNatures",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_jobNature_Projects_ProjectId",
+                table: "jobNature",
+                column: "ProjectId",
+                principalTable: "Projects",
+                principalColumn: "Id");
+        }
+    }
+}


### PR DESCRIPTION
refactor: Rename jobNature to Employees and seed data

- Refactored `EmployeeService` and `EEMSDbContext` to replace `jobNature` with `Employees`.
- Updated methods in `EmployeeService` to use the new `Employees` DbSet.
- Added data seeding for `Department`, `Project`, `JobNature`, and `Employee` entities.
- Created migration files to rename `jobNature` table to
  `Employees` and update foreign key relationships.
- Introduced `SeedEmployeeData` migration to insert predefined employee records.
- Enhanced code clarity and standardized naming conventions in the database schema.