### PR TITLE
feat: add Condidate and OpenedJob entities

### DIFF
--- a/EEMS.BusinessLogic/Interfaces/ICondidateManagementService.cs
+++ b/EEMS.BusinessLogic/Interfaces/ICondidateManagementService.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EEMS.BusinessLogic.Interfaces;
+
+public class ICondidateManagementService
+{
+    IJobNatureService JobNatureService { get; }
+    ICondidateService CondidateService { get; }
+    
+}

--- a/EEMS.BusinessLogic/Interfaces/ICondidateService.cs
+++ b/EEMS.BusinessLogic/Interfaces/ICondidateService.cs
@@ -1,0 +1,17 @@
+﻿using EEMS.DataAccess.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EEMS.BusinessLogic.Interfaces;
+
+public interface ICondidateService
+{
+    Task<IEnumerable<Condidate>> GetAsync();
+    Task<Condidate> GetAsync(int id);
+    Task<int> AddAsync(Condidate condidate);
+    Task<bool> DeleteAsync(int id);
+    Task UpdateAsync(Condidate condidate);
+}

--- a/EEMS.BusinessLogic/Interfaces/IOpenedJobService.cs
+++ b/EEMS.BusinessLogic/Interfaces/IOpenedJobService.cs
@@ -1,0 +1,17 @@
+﻿using EEMS.DataAccess.Models;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EEMS.BusinessLogic.Interfaces;
+
+public interface IOpenedJobService
+{
+    Task<int> AddAsync(OpenedJob opendJob);
+    Task DeleteAsync(int id);
+    Task<IEnumerable<OpenedJob>> GetAsync();
+    Task<OpenedJob> GetAsync(int id);
+    Task UpdateAsync(OpenedJob opendJob);
+}

--- a/EEMS.BusinessLogic/Services/CondidateService.cs
+++ b/EEMS.BusinessLogic/Services/CondidateService.cs
@@ -1,0 +1,61 @@
+﻿using EEMS.BusinessLogic.Interfaces;
+using EEMS.DataAccess;
+using EEMS.DataAccess.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace EEMS.BusinessLogic.Services;
+
+public class CondidateService : ICondidateService
+{
+    private readonly IDbContextFactory<EEMSDbContext> _contextFactory;
+    public CondidateService(IDbContextFactory<EEMSDbContext> contextFactory)
+    {
+        _contextFactory = contextFactory;
+    }
+    public async Task<int> AddAsync(Condidate condidate)
+    {
+        await using var context = _contextFactory.CreateDbContext();
+        var added = context.Condidates.Add(condidate);
+        await context.SaveChangesAsync();
+
+        return added.Entity.Id;
+    }
+
+    public async Task<bool> DeleteAsync(int id)
+    {
+        await using var context = _contextFactory.CreateDbContext();
+        var condidate = await GetAsync(id);
+        if (condidate != null)
+        {
+            context.Condidates.Remove(condidate);
+            await context.SaveChangesAsync();
+            return true;
+        }
+        return false;
+    }
+
+    public async Task<IEnumerable<Condidate>> GetAsync()
+    {
+        await using var context = _contextFactory.CreateDbContext();
+        return await context.Condidates
+            .Include(b => b.JobNature)
+            .Include(c => c.OpenedJob)
+            .ToListAsync();
+    }
+
+    public async Task<Condidate> GetAsync(int id)
+    {
+        await using var context = _contextFactory.CreateDbContext();
+        return await context.Condidates
+            .Include(b => b.JobNature)
+            .Include(c => c.OpenedJob)
+            .FirstAsync(e => e.Id == id);
+    }
+
+    public async Task UpdateAsync(Condidate condidate)
+    {
+        await using var context = _contextFactory.CreateDbContext();
+        context.Condidates.Update(condidate);
+        await context.SaveChangesAsync();
+    }
+}

--- a/EEMS.BusinessLogic/Services/OpendJobService.cs
+++ b/EEMS.BusinessLogic/Services/OpendJobService.cs
@@ -1,0 +1,59 @@
+﻿using EEMS.BusinessLogic.Interfaces;
+using EEMS.DataAccess;
+using EEMS.DataAccess.Models;
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EEMS.BusinessLogic.Services;
+
+public class OpendJobService : IOpenedJobService
+{
+    private readonly IDbContextFactory<EEMSDbContext> _contextFactory;
+    public OpendJobService(IDbContextFactory<EEMSDbContext> contextFactory)
+    {
+        _contextFactory = contextFactory;
+    }
+
+    public async Task<int> AddAsync(OpenedJob opendJob)
+    {
+        await using var context = _contextFactory.CreateDbContext();
+        var added = context.Openedjobs.Add(opendJob);
+        await context.SaveChangesAsync();
+
+        return added.Entity.Id;
+    }
+
+    public async Task DeleteAsync(int id)
+    {
+        await using var context = _contextFactory.CreateDbContext();
+        var openedJob = await GetAsync(id);
+        if (openedJob != null)
+        {
+            context.Openedjobs.Remove(openedJob);
+            await context.SaveChangesAsync();
+        }
+    }
+
+    public async Task<IEnumerable<OpenedJob>> GetAsync()
+    {
+        await using var context = _contextFactory.CreateDbContext();
+        return await context.Openedjobs.ToListAsync();
+    }
+
+    public async Task<OpenedJob> GetAsync(int id)
+    {
+        await using var context = _contextFactory.CreateDbContext();
+        return await context.Openedjobs.FindAsync(id);
+    }
+
+    public async Task UpdateAsync(OpenedJob opendJob)
+    {
+        await using var context = _contextFactory.CreateDbContext();
+        context.Openedjobs.Update(opendJob);
+        await context.SaveChangesAsync();
+    }
+}

--- a/EEMS.DataAccess/EEMSDbContext.cs
+++ b/EEMS.DataAccess/EEMSDbContext.cs
@@ -12,6 +12,8 @@ public class EEMSDbContext : DbContext
     public DbSet<Absence> Absences { get; set; }
     public DbSet<Account> Accounts { get; set; }
     public DbSet<JobNature> JobNatures { get; set; }
+    public DbSet<Condidate> Condidates { get; set; }
+    public DbSet<OpenedJob> Openedjobs { get; set; }
     //public DbSet<AbsenceType> AbsenceTypes { get; set; }
     //public DbSet<DrivingLicenseType> DrivingLicenseTypes { get; set; }
     //public DbSet<EmployeeDrivingLicense> EmployeeDrivingLicenses { get; set; }
@@ -153,6 +155,19 @@ public class EEMSDbContext : DbContext
         //    .Property(s => s.DateHappened)
         //    .HasColumnType("date");
 
+
+        //Condidate relations
+        // One to Many: OpendJob -> Condidate
+        modelBuilder.Entity<Condidate>()
+            .HasOne(c => c.OpenedJob)
+            .WithMany(o => o.Condidates)
+            .HasForeignKey(c => c.OpenedJobId);
+
+        // One to Many: JobNature -> Condidate
+        modelBuilder.Entity<Condidate>()
+            .HasOne(c => c.JobNature)
+            .WithMany(j => j.Condidates)
+            .HasForeignKey(c => c.JobNatureId);
 
         // Data seeding
 

--- a/EEMS.DataAccess/Models/Condidate.cs
+++ b/EEMS.DataAccess/Models/Condidate.cs
@@ -1,0 +1,56 @@
+﻿using EEMS.Utilities.Enums;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EEMS.DataAccess.Models;
+
+public class Condidate
+{
+    public int Id { get; set; }
+    public string FirstName { get; set; }
+    public string LastName { get; set; }
+    [Phone]
+    public string Phone { get; set; }
+    [EmailAddress]
+    public string Email { get; set; }
+    public string Training { get; set; }
+    public DateTime DateOfBirth { get; set; }
+    public string BirthLocation { get; set; }
+    public string Address { get; set; }
+    public FamilySituation FamilySituation { get; set; }
+    public DateTime InterviewDate { get; set; }
+    public Gender Gender { get; set; }
+    public string? EssentialTraining { get; set; }
+    public string? LanguagesSpoken { get; set; }
+    public int? Experience { get; set; }
+    public string Residence { get; set; }
+    public bool IsArchived { get; set; }
+    public DrivingLicense HasDrivingLicence { get; set; }
+    public bool KnowMicrosoftOfficeSoftware { get; set; }
+    public string FatherFullName { get; set; }
+    public string MotherFullName { get; set; }
+    public string FatherJob { get; set; }
+    public string MotherJob { get; set; }
+    public string BloodGroup { get; set; }
+    public int NumberOfBrothersAndSisters { get; set; }
+    public string HusbandFullname { get; set; }
+    public string HusbandJob { get; set; }
+    public string BankAccountNumber { get; set; }
+    public string SocialSecurityNumber { get; set; }
+    public string NationalCardNumber { get; set; }
+    public DateTime NationalCardNumberReleaseDate { get; set; }
+    public bool ClearedFromNationalService { get; set; }
+    public DateTime NationalServiceDateSuspendedFrom { get; set; }
+    public DateTime NationalServiceDateSuspendedTo { get; set; }
+    public bool NationalServiceSuitableNotIncorporated { get; set; }
+
+    public int? OpenedJobId { get; set; }
+    public virtual OpenedJob OpenedJob { get; set; }
+
+    public int? JobNatureId { get; set; }
+    public virtual JobNature JobNature { get; set; }
+}

--- a/EEMS.DataAccess/Models/Employee.cs
+++ b/EEMS.DataAccess/Models/Employee.cs
@@ -1,48 +1,47 @@
 ﻿using EEMS.Utilities.Enums;
 using System.ComponentModel.DataAnnotations;
 
-namespace EEMS.DataAccess.Models
+namespace EEMS.DataAccess.Models;
+
+public class Employee
 {
-    public class Employee
-    {
-        public int Id { get; set; }
-        public string FirstName { get; set; }//
-        public string LastName { get; set; }//
-        [Phone]
-        public string Phone { get; set; }//
-        public string JobTitle { get; set; }
-        [EmailAddress]
-        public string Email { get; set; }//
-        public string Training { get; set; }///
-        public DateTime DateOfBirth { get; set; }//
-        public string BirthLocation { get; set; }//
-        public string Address { get; set; }//
-        public FamilySituation FamilySituation { get; set; }//
-        public DateTime RecruitmentDate { get; set; }///
-        public Gender Gender { get; set; }//
-        public string? EssentialTraining { get; set; }///
-        public string? LanguagesSpoken { get; set; }///
-        public int? Experience { get; set; }///
-        public string Residence { get; set; }//
-        public Status IsActive { get; set; }
-        public bool IsArchived { get; set; }
+    public int Id { get; set; }
+    public string FirstName { get; set; }//
+    public string LastName { get; set; }//
+    [Phone]
+    public string Phone { get; set; }//
+    public string JobTitle { get; set; }
+    [EmailAddress]
+    public string Email { get; set; }//
+    public string Training { get; set; }///
+    public DateTime DateOfBirth { get; set; }//
+    public string BirthLocation { get; set; }//
+    public string Address { get; set; }//
+    public FamilySituation FamilySituation { get; set; }//
+    public DateTime RecruitmentDate { get; set; }///
+    public Gender Gender { get; set; }//
+    public string? EssentialTraining { get; set; }///
+    public string? LanguagesSpoken { get; set; }///
+    public int? Experience { get; set; }///
+    public string Residence { get; set; }//
+    public Status IsActive { get; set; }
+    public bool IsArchived { get; set; }
 
-        public int? DepartmentId { get; set; }
-        public virtual Department Department { get; set; }
+    public int? DepartmentId { get; set; }
+    public virtual Department Department { get; set; }
 
-        public int? JobNatureId { get; set; }
-        public virtual JobNature JobNature { get; set; }
+    public int? JobNatureId { get; set; }
+    public virtual JobNature JobNature { get; set; }
 
-        //public int? LeaveId { get; set; }
-        //public virtual Leave Leave { get; set; }
+    //public int? LeaveId { get; set; }
+    //public virtual Leave Leave { get; set; }
 
 
-        public virtual ICollection<Absence> Absences { get; set; } = new List<Absence>();
-        //public virtual ICollection<Vacation> Vacations { get; set; } = new List<Vacation>();
-        //public virtual ICollection<EmployeeDrivingLicense> EmployeeDrivingLicenses { get; set; } = new List<EmployeeDrivingLicense>();
-        //public virtual ICollection<EmployeeTraining> EmployeesTraining { get; set; } = new List<EmployeeTraining>();
-        //public virtual ICollection<Diploma> Diplomas { get; set; } = new List<Diploma>();
-        //public virtual ICollection<Sanction> Sanctions { get; set; } = new List<Sanction>();
+    public virtual ICollection<Absence> Absences { get; set; } = new List<Absence>();
+    //public virtual ICollection<Vacation> Vacations { get; set; } = new List<Vacation>();
+    //public virtual ICollection<EmployeeDrivingLicense> EmployeeDrivingLicenses { get; set; } = new List<EmployeeDrivingLicense>();
+    //public virtual ICollection<EmployeeTraining> EmployeesTraining { get; set; } = new List<EmployeeTraining>();
+    //public virtual ICollection<Diploma> Diplomas { get; set; } = new List<Diploma>();
+    //public virtual ICollection<Sanction> Sanctions { get; set; } = new List<Sanction>();
 
-    }
 }

--- a/EEMS.DataAccess/Models/OpenedJob.cs
+++ b/EEMS.DataAccess/Models/OpenedJob.cs
@@ -6,11 +6,12 @@ using System.Threading.Tasks;
 
 namespace EEMS.DataAccess.Models;
 
-public class JobNature
+public class OpenedJob
 {
     public int Id { get; set; }
     public string Name { get; set; }
+    public int DepartmentId { get; set; }
+    public virtual Department Department { get; set; }
 
-    public virtual ICollection<Employee> Employees { get; set; } = new List<Employee>();
     public virtual ICollection<Condidate> Condidates { get; set; } = new List<Condidate>();
 }

--- a/EEMS.Utilities/Enums/DrivingLicense.cs
+++ b/EEMS.Utilities/Enums/DrivingLicense.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EEMS.Utilities.Enums;
+
+public enum DrivingLicense
+{
+    Have,
+    NotHave,
+}

--- a/EEMS/App.xaml
+++ b/EEMS/App.xaml
@@ -618,7 +618,7 @@
                                                     Command="{x:Static DataGrid.SelectAllCommand}"
                                                     Focusable="false"
                                                     Style="{DynamicResource {ComponentResourceKey ResourceId=DataGridSelectAllButtonStyle,
-                                                    TypeInTargetAssembly={x:Type DataGrid}}}"
+                                                                                                  TypeInTargetAssembly={x:Type DataGrid}}}"
                                                     Visibility="{Binding HeadersVisibility, ConverterParameter={x:Static DataGridHeadersVisibility.All}, Converter={x:Static DataGrid.HeadersVisibilityConverter}, RelativeSource={RelativeSource AncestorType={x:Type DataGrid}}}" />
                                                 <DataGridColumnHeadersPresenter
                                                     x:Name="PART_ColumnHeadersPresenter"

--- a/EEMS/App.xaml.cs
+++ b/EEMS/App.xaml.cs
@@ -4,6 +4,7 @@ using EEMS.DataAccess;
 using EEMS.UI.UserControls;
 using EEMS.UI.ViewModels;
 using EEMS.UI.Views.Absences;
+using EEMS.UI.Views.Condidates;
 using EEMS.UI.Views.Dashboard;
 using EEMS.UI.Views.Employees;
 using EEMS.UI.Views.Shared;
@@ -50,6 +51,7 @@ public partial class App : Application
         service.AddTransient<IJobNatureService, JobNatureService>();
         service.AddTransient<IEmployeeManagementService, EmployeeManagementService>();
         service.AddTransient<IAbsenceService, AbsenceService>();
+        service.AddTransient<ICondidateService, CondidateService>();
 
         // Register ViewModels
         service.AddTransient<EmployeeViewModel>();
@@ -60,12 +62,14 @@ public partial class App : Application
         service.AddTransient<ViewAbsenceDetailsViewModel>();
         service.AddTransient<SingleButtonMessageBoxViewModel>();
         service.AddTransient<TwoButtonMessageBoxViewModel>();
+        service.AddTransient<CondidatePageViewModel>();
         
 
         // Register pages
         service.AddTransient<EmployeePage>();
         service.AddTransient<DashboardPage>();
         service.AddTransient<AbsencePage>();
+        service.AddTransient<CondidatePage>();
 
 
         //Register Views

--- a/EEMS/MainWindow.xaml
+++ b/EEMS/MainWindow.xaml
@@ -229,10 +229,51 @@
                                 </StackPanel>
                             </Button>
 
-                            <Button Style="{StaticResource menuButton}">
+                            <!--<Button Style="{StaticResource menuButton}">
+                            <StackPanel Orientation="Horizontal">
+                            <Icon:PackIconMaterial Kind="ForumOutline" Style="{StaticResource menuButtonIcon}" />
+                            <TextBlock Text="Condidates" Visibility="{Binding IsMenuExpanded, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                            </StackPanel>
+                            </Button>-->
+                            <Button Command="{Binding NavigateToCondidatePageCommand}">
+                                <Button.Style>
+                                    <Style BasedOn="{StaticResource menuButton}" TargetType="Button">
+                                        <Style.Triggers>
+                                            <DataTrigger Binding="{Binding ActivePage}" Value="Condidate">
+                                                <DataTrigger.EnterActions>
+                                                    <BeginStoryboard>
+                                                        <Storyboard>
+                                                            <ColorAnimation
+                                                                FillBehavior="HoldEnd"
+                                                                Storyboard.TargetProperty="(Background).(SolidColorBrush.Color)"
+                                                                To="#6895ff"
+                                                                Duration="0:0:0.3" />
+                                                        </Storyboard>
+                                                    </BeginStoryboard>
+                                                </DataTrigger.EnterActions>
+                                                <DataTrigger.ExitActions>
+                                                    <BeginStoryboard>
+                                                        <Storyboard>
+                                                            <ColorAnimation
+                                                                FillBehavior="HoldEnd"
+                                                                Storyboard.TargetProperty="(Background).(SolidColorBrush.Color)"
+                                                                To="Transparent"
+                                                                Duration="0:0:0.3" />
+                                                        </Storyboard>
+                                                    </BeginStoryboard>
+                                                </DataTrigger.ExitActions>
+                                            </DataTrigger>
+                                        </Style.Triggers>
+                                    </Style>
+                                </Button.Style>
+
+                                <Button.Background>
+                                    <SolidColorBrush Color="Transparent" />
+                                </Button.Background>
+
                                 <StackPanel Orientation="Horizontal">
-                                    <Icon:PackIconMaterial Kind="ForumOutline" Style="{StaticResource menuButtonIcon}" />
-                                    <TextBlock Text="Condidates" Visibility="{Binding IsMenuExpanded, Converter={StaticResource BooleanToVisibilityConverter}}" />
+                                    <Icon:PackIconMaterial Kind="Tree" Style="{StaticResource menuButtonIcon}" />
+                                    <TextBlock Text="Condidate" Visibility="{Binding IsMenuExpanded, Converter={StaticResource BooleanToVisibilityConverter}}" />
                                 </StackPanel>
                             </Button>
 

--- a/EEMS/ViewModels/AddAndEditWindowViewModel.cs
+++ b/EEMS/ViewModels/AddAndEditWindowViewModel.cs
@@ -7,13 +7,13 @@ using EEMS.Utilities.Enums;
 using System.Collections.ObjectModel;
 using System.ComponentModel.DataAnnotations;
 using System.Windows;
+using System.Windows.Controls.Primitives;
 
 namespace EEMS.UI.ViewModels;
 
 public partial class AddAndEditWindowViewModel : ObservableValidator
 {
 	private readonly IEmployeeManagementService _employeeManagementService;
-	private bool _isEditing = false;
 
     [ObservableProperty] [Required(ErrorMessage ="First name cannot be empty")] private string _firstName;
     [ObservableProperty] [Required(ErrorMessage = "Last name cannot be empty")] private string _lastName;
@@ -34,6 +34,7 @@ public partial class AddAndEditWindowViewModel : ObservableValidator
     [ObservableProperty] [Required(ErrorMessage = "Job Nature cannot be empty")] private JobNature _selectedJobNature;
     [ObservableProperty] [Required(ErrorMessage = "recruitment date cannot be empty")] private DateTime _selectedRecruitmentDate;
     [ObservableProperty] [Required(ErrorMessage = "Status cannot be empty")] private Status _selectedStatus;
+    [ObservableProperty] private string _buttonName = "Save";
     public ObservableCollection<Department> DepartmentItems { get; } = new();
     public ObservableCollection<JobNature> JobNatureItems { get; } = new();
     public ObservableCollection<FamilySituation> FamilySituationItems { get; } = new();
@@ -111,13 +112,47 @@ public partial class AddAndEditWindowViewModel : ObservableValidator
 
     public AddAndEditWindowViewModel( IEmployeeManagementService employeeManagementService)
 	{
-		_employeeManagementService = employeeManagementService;
+        ButtonName = "Save";    
+        _employeeManagementService = employeeManagementService;
         SelectedBirthDate = DateTime.Today;
         SelectedRecruitmentDate = DateTime.Today;
         LoadFamilySituation();
         _ = LoadDepartmentsAsync();
         _ = LoadJobNatureAsync();
+    }
 
+    public AddAndEditWindowViewModel(IEmployeeManagementService employeeManagementService,Employee employee)
+    {
+        ButtonName = "Update";
+        _employeeManagementService = employeeManagementService;
+        LoadFamilySituation();
+        _ = LoadDepartmentsAsync();
+        _ = LoadJobNatureAsync();
+        LoadEmployeeDetail(employee);
+    }
+
+    private void LoadEmployeeDetail(Employee employee)
+    {
+        FirstName = employee.FirstName;
+        LastName = employee.LastName;
+        Phone = employee.Phone;
+        Address = employee.Address;
+        SelectedGender = (Gender)employee.FamilySituation;
+        Email = employee.Email;
+        SelectedBirthDate = employee.DateOfBirth;
+        BirthLocation = employee.BirthLocation;
+        SelectedFamilySituation = employee.FamilySituation;
+        Residence = employee.Residence;
+
+        JobTitle = employee.JobTitle;
+        EssentialTraining = employee.EssentialTraining ?? "";
+        OtherTraining = employee.Training;
+        SpokenLanguages = employee.LanguagesSpoken ?? "";
+        Experience = (int)employee.Experience;
+        SelectedDepartment = DepartmentItems.FirstOrDefault(d => d.Id == employee.Department?.Id);
+        SelectedJobNature = JobNatureItems.FirstOrDefault(n => n.Id == employee.JobNature?.Id);
+        SelectedRecruitmentDate = employee.RecruitmentDate;
+        SelectedStatus = employee.IsActive;
     }
 
     private void LoadFamilySituation()

--- a/EEMS/ViewModels/CondidatePageViewModel.cs
+++ b/EEMS/ViewModels/CondidatePageViewModel.cs
@@ -1,0 +1,17 @@
+﻿using CommunityToolkit.Mvvm.ComponentModel;
+using EEMS.BusinessLogic.Interfaces;
+using EEMS.DataAccess.Models;
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace EEMS.UI.ViewModels;
+
+public class CondidatePageViewModel : ObservableObject
+{
+    private readonly IEmployeeManagementService _employeeManagementService;
+    public ObservableCollection<Employee> Employees { get; set; }
+}

--- a/EEMS/ViewModels/EmployeeViewModel.cs
+++ b/EEMS/ViewModels/EmployeeViewModel.cs
@@ -20,25 +20,13 @@ public partial class EmployeeViewModel : ObservableObject
 
     [ObservableProperty] private Employee _selectedEmployee;
     [ObservableProperty] private string _selectedTab = "All";
-    [ObservableProperty] private bool _isEditing;
+    //[ObservableProperty] private bool _isEditing;
     [ObservableProperty] private Department _selectedDepartment;
     [ObservableProperty] private string _searchEmployee;
 
     private List<Employee> _filteredEmployees = new List<Employee>();
 
-    public bool IsNotEditing => !IsEditing;
-
-    [RelayCommand(CanExecute = nameof(CanPerformUserAction))]
-    private void ViewEmployee(object obj)
-    {
-        if (SelectedEmployee != null)
-        {
-            var employeeDetails = new ViewEmployeeDetailsViewModel(SelectedEmployee);
-            var viewEmployeeDetailsWindow = new ViewEmployeeDetails(employeeDetails);
-            viewEmployeeDetailsWindow.ShowDialog();
-            SelectedEmployee = null;
-        }
-    }
+    //public bool IsNotEditing => !IsEditing;
 
     [RelayCommand]
     private void SelectTab(string tabName)
@@ -49,14 +37,14 @@ public partial class EmployeeViewModel : ObservableObject
 
     private bool CanPerformUserAction(object obj)
     {
-        return SelectedEmployee != null && !IsEditing;
+        return SelectedEmployee != null;
     }
 
-    partial void OnIsEditingChanged(bool value)
-    {
-        OnPropertyChanged(nameof(IsNotEditing));
-        ViewEmployeeCommand.NotifyCanExecuteChanged();
-    }
+    //partial void OnIsEditingChanged(bool value)
+    //{
+    //    OnPropertyChanged(nameof(IsNotEditing));
+    //    ViewEmployeeCommand.NotifyCanExecuteChanged();
+    //}
 
     partial void OnSelectedEmployeeChanged(Employee value)
     {
@@ -91,7 +79,6 @@ public partial class EmployeeViewModel : ObservableObject
         _employeeManagementService = employeeManagementService;
         Employees = new ObservableCollection<Employee>();
         Departments = new ObservableCollection<Department>();
-        IsEditing = false;
         LoadDepartmentsToCombobox();
     }
 
@@ -170,20 +157,33 @@ public partial class EmployeeViewModel : ObservableObject
         AddAndEditWindow.ShowDialog();
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanPerformUserAction))]
+    private void ViewEmployee(object obj)
+    {
+        if (SelectedEmployee != null)
+        {
+            var employeeDetails = new ViewEmployeeDetailsViewModel(SelectedEmployee);
+            var viewEmployeeDetailsWindow = new ViewEmployeeDetails(employeeDetails);
+            viewEmployeeDetailsWindow.ShowDialog();
+            SelectedEmployee = null;
+        }
+    }
+
+    [RelayCommand(CanExecute = nameof(CanPerformUserAction))]
     private void EditEmployee(object obj)
     {
         if (SelectedEmployee != null)
         {
-           
             //viewModel.UpdateGridWindowData = LoadEmployees;
-            //var addAndEditWindow = new AddAndEditWindow(viewModel);
-            //addAndEditWindow.ShowDialog();
+            var viewModel = new AddAndEditWindowViewModel(_employeeManagementService, SelectedEmployee);
+            var addAndEditWindow = new AddAndEditWindow(viewModel);
+            addAndEditWindow.ShowDialog();
+            SelectedEmployee = null;
         }
     }
 
-    [RelayCommand]
-    private async void DeleteEmployee()
+    [RelayCommand(CanExecute = nameof(CanPerformUserAction))]
+    private async void DeleteEmployee(object obj)
     {
         if (SelectedEmployee != null)
         {

--- a/EEMS/ViewModels/MainWindowViewModel.cs
+++ b/EEMS/ViewModels/MainWindowViewModel.cs
@@ -1,6 +1,7 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using EEMS.UI.Views.Absences;
+using EEMS.UI.Views.Condidates;
 using EEMS.UI.Views.Dashboard;
 using EEMS.UI.Views.Employees;
 using EEMS.UI.Views.Shared;
@@ -62,6 +63,13 @@ public partial class MainWindowViewModel : ObservableObject
     {
         ActivePage = "Absence";
         _navigationService.NavigateTo<AbsencePage>();
+    }
+
+    [RelayCommand]
+    private void NavigateToCondidatePage()
+    {
+        ActivePage = "Condidate";
+        _navigationService.NavigateTo<CondidatePage>();
     }
 
 }

--- a/EEMS/Views/Condidates/CondidatePage.xaml
+++ b/EEMS/Views/Condidates/CondidatePage.xaml
@@ -1,0 +1,215 @@
+﻿<Page
+    x:Class="EEMS.UI.Views.Condidates.CondidatePage"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:Icon="http://metro.mahapps.com/winfx/xaml/iconpacks"
+    xmlns:UC="clr-namespace:EEMS.UI.UserControls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:EEMS.UI.Views.Condidates"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Title="CondidatePage"
+    d:DesignHeight="450"
+    d:DesignWidth="800"
+    mc:Ignorable="d">
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="auto" />
+            <RowDefinition Height="auto" />
+            <RowDefinition Height="auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+
+        <!--  Page Title  -->
+
+        <TextBlock
+            HorizontalAlignment="Left"
+            VerticalAlignment="Center"
+            FontSize="32"
+            FontWeight="SemiBold"
+            Foreground="#121518"
+            Text="Condidates" />
+
+        <!--  Add Employee Button  -->
+        <UC:VioletButtonFill
+            Grid.Row="0"
+            Margin="0,0,5,0"
+            HorizontalAlignment="Right"
+            VerticalAlignment="Center"
+            Command="{Binding AddCondidateCommand}"
+            PlaceholderText="Add Condidate" />
+
+        <!--  Tab Button  -->
+        <StackPanel
+            Grid.Row="1"
+            Margin="0,10,0,0"
+            Orientation="Horizontal">
+            <Button
+                VerticalAlignment="Top"
+                BorderBrush="{Binding SelectedTab, Converter={StaticResource TabSelectedToBrushConverter}, ConverterParameter=All}"
+                Command="{Binding SelectTabCommand}"
+                CommandParameter="All"
+                Content="All">
+                <Button.Style>
+                    <Style BasedOn="{StaticResource tabButton}" TargetType="Button">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding SelectedTab}" Value="All">
+                                <Setter Property="BorderBrush" Value="{StaticResource PrimaryColor}" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+                </Button.Style>
+            </Button>
+            <!--<Button
+            BorderBrush="{Binding SelectedTab, Converter={StaticResource TabSelectedToBrushConverter}, ConverterParameter=Absence}"
+            Command="{Binding SelectTabCommand}"
+            CommandParameter="Absence"
+            Content="Absence">
+            <Button.Style>
+            <Style BasedOn="{StaticResource tabButton}" TargetType="Button">
+            <Style.Triggers>
+            <DataTrigger Binding="{Binding SelectedTab}" Value="Absence">
+            <Setter Property="BorderBrush" Value="{StaticResource PrimaryColor}" />
+            </DataTrigger>
+            </Style.Triggers>
+            </Style>
+            </Button.Style>
+            </Button>
+            <Button Content="Training" Style="{StaticResource tabButton}" />
+            <Button Content="Vacation" Style="{StaticResource tabButton}" />
+            <Button Content="Sanction" Style="{StaticResource tabButton}" />-->
+        </StackPanel>
+
+
+
+        <!--  Filter Textbox  -->
+
+        <Grid Grid.Row="1">
+            <StackPanel HorizontalAlignment="Right" Orientation="Horizontal">
+                <!--  search by job nature  -->
+                <TextBlock
+                    VerticalAlignment="Center"
+                    FontSize="13"
+                    FontWeight="SemiBold"
+                    Foreground="#121517"
+                    Text="Job Nature" />
+                <ComboBox
+                    Width="150"
+                    Height="24"
+                    Margin="5,0"
+                    BorderBrush="#97a5b4"
+                    BorderThickness="1"
+                    DisplayMemberPath="Name"
+                    Foreground="#868686"
+                    ItemsSource="{Binding JobNatureItems}"
+                    SelectedItem="{Binding SelectedJobNature, UpdateSourceTrigger=PropertyChanged}"
+                    Text="All" />
+                <!--  search by departments  -->
+                <TextBlock
+                    VerticalAlignment="Center"
+                    FontSize="13"
+                    FontWeight="SemiBold"
+                    Foreground="#121517"
+                    Text="Opened Jobs" />
+                <ComboBox
+                    Width="180"
+                    Height="24"
+                    Margin="5,0"
+                    BorderBrush="#97a5b4"
+                    BorderThickness="1"
+                    DisplayMemberPath="Name"
+                    Foreground="#868686"
+                    ItemsSource="{Binding OpenedJobItems}"
+                    SelectedItem="{Binding SelectedOpenJob, UpdateSourceTrigger=PropertyChanged}"
+                    Text="All" />
+
+                <UC:SearchTextBoxControl
+                    Width="210"
+                    Margin="5,0,5,0"
+                    HorizontalAlignment="Right"
+                    PlaceholderText="Search Condidate.."
+                    Text="{Binding SearchCondidate, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
+            </StackPanel>
+        </Grid>
+
+        <!--  Separator  -->
+        <Separator
+            Grid.Row="2"
+            Height="1"
+            Margin="0,-1,0,10"
+            Background="#dae2ea" />
+
+        <!--  Employees Datagrid  -->
+        <DataGrid
+            x:Name="membersDataGrid"
+            Grid.Row="3"
+            CellStyle="{DynamicResource DataGridCellStyle1}"
+            ColumnHeaderStyle="{DynamicResource DataGridColumnHeaderStyle1}"
+            ItemsSource="{Binding Employees}"
+            RowStyle="{DynamicResource DataGridRowStyle1}"
+            SelectedItem="{Binding SelectedEmployee, Mode=TwoWay}"
+            Style="{DynamicResource DataGridStyle1}">
+            <DataGrid.ContextMenu>
+                <ContextMenu>
+                    <MenuItem Command="{Binding ViewCondidateCommand}" Header="View" />
+                    <MenuItem Command="{Binding EditCondidateCommand}" Header="Edit" />
+                    <MenuItem Command="{Binding ArchiveCondidateCommand}" Header="Archiver" />
+                    <MenuItem Command="{Binding DeleteCondidateCommand}" Header="Supprimer" />
+                    <MenuItem Command="{Binding PrintCondidateCommand}" Header="Imprimer" />
+                </ContextMenu>
+            </DataGrid.ContextMenu>
+            <DataGrid.Columns>
+                <DataGridTextColumn
+                    Width="auto"
+                    Binding="{Binding Id}"
+                    CanUserResize="False"
+                    Header="#"
+                    IsReadOnly="True" />
+                <DataGridTemplateColumn
+                    Width="*"
+                    Header=" Full Name"
+                    IsReadOnly="True">
+                    <DataGridTemplateColumn.CellTemplate>
+                        <DataTemplate>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock VerticalAlignment="Center" Text="{Binding FirstName}" />
+                                <TextBlock
+                                    Margin="5,0,0,0"
+                                    VerticalAlignment="Center"
+                                    Text="{Binding LastName}" />
+                            </StackPanel>
+                        </DataTemplate>
+                    </DataGridTemplateColumn.CellTemplate>
+                </DataGridTemplateColumn>
+
+                <DataGridTextColumn
+                    Width="*"
+                    Binding="{Binding JobNature}"
+                    CanUserResize="False"
+                    Header="Position"
+                    IsReadOnly="True" />
+
+                <DataGridTextColumn
+                    Width="*"
+                    Binding="{Binding Email}"
+                    CanUserResize="False"
+                    Header="Email"
+                    IsReadOnly="True" />
+
+                <DataGridTextColumn
+                    Width="*"
+                    Binding="{Binding Phone}"
+                    CanUserResize="False"
+                    Header="Phone"
+                    IsReadOnly="True" />
+
+                <DataGridTextColumn
+                    Width="*"
+                    Binding="{Binding Gender}"
+                    CanUserResize="False"
+                    Header="Gender"
+                    IsReadOnly="True" />
+            </DataGrid.Columns>
+        </DataGrid>
+    </Grid>
+</Page>

--- a/EEMS/Views/Condidates/CondidatePage.xaml.cs
+++ b/EEMS/Views/Condidates/CondidatePage.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Navigation;
+using System.Windows.Shapes;
+
+namespace EEMS.UI.Views.Condidates
+{
+    /// <summary>
+    /// Interaction logic for CondidatePage.xaml
+    /// </summary>
+    public partial class CondidatePage : Page
+    {
+        public CondidatePage()
+        {
+            InitializeComponent();
+        }
+    }
+}

--- a/EEMS/Views/Employees/AddAndEditWindow.xaml
+++ b/EEMS/Views/Employees/AddAndEditWindow.xaml
@@ -570,7 +570,7 @@
                                             Margin="0,40,20,0"
                                             HorizontalAlignment="Right"
                                             Command="{Binding SaveEmployeeCommand}"
-                                            Content="Save"
+                                            Content="{Binding ButtonName}"
                                             Style="{StaticResource mainButton}">
                                             <Button.Effect>
                                                 <DropShadowEffect


### PR DESCRIPTION
feat: add Condidate and OpenedJob entities

- Added DbSet properties for `Condidate` and `OpenedJob` in 
  `EEMSDbContext`.
- Established one-to-many relationships for `Condidate` with 
  `OpenedJob` and `JobNature`.
- Restructured the `Employee` class and updated data annotations.
- Modified `JobNature` to include a collection of `Condidate` entities.
- Registered new services and view models for `Condidate` in 
  `App.xaml.cs`.
- Added navigation button for `Condidate` page in `MainWindow.xaml`.
- Introduced `Condidate` and `OpenedJob` classes with relevant 
  properties.
- Implemented `ICondidateService` and `CondidateService` for CRUD 
  operations.
- Created `IOpenedJobService` and `OpendJobService` for managing 
  job openings.
- Added `CondidatePage` and its view model for displaying 
  candidate data.
- Updated `AddAndEditWindowViewModel` for handling both 
  `Employee` and `Condidate`.
- Streamlined `EmployeeViewModel` by removing editing logic.
- Enhanced `CondidatePage.xaml` with UI elements for managing 
  candidates.
- Added code-behind for `CondidatePage` in 
  `CondidatePage.xaml.cs`.
- Introduced `DrivingLicense` enum for candidate status.
- Made adjustments for proper binding and command handling in 
  view models and XAML files.

